### PR TITLE
feat: add main script for npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ List of CJ NAT addresses suitable for source IP whitelisting.
 
 ## Usage
 
+### In the Shell
+
+```
+npx @cjdev/nataddr
+```
+
+will display the list of nat IP addresses in the format `<Address Type> <Address>`.
+
+### As a Library
+
 Install into your project: `npm i @cjdev/nataddr`
 
 ``` typescript

--- a/main.js
+++ b/main.js
@@ -3,6 +3,6 @@ const nat = require("./dist/index");
 console.log(
   nat
     .all()
-    .map(({ type, descriptor }) => `${nat.AddressType[type]}\t${descriptor}`)
+    .map(({ type, descriptor }) => `${nat.AddressType[type]} ${descriptor}`)
     .join("\n")
 );

--- a/main.js
+++ b/main.js
@@ -1,0 +1,8 @@
+const nat = require("./dist/index");
+
+console.log(
+  nat
+    .all()
+    .map(({ type, descriptor }) => `${nat.AddressType[type]}\t${descriptor}`)
+    .join("\n")
+);

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "@cjdev/nataddr",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "NAT addresses for whitelisting",
   "repository": {
     "type": "git",
     "url": "https://github.com/cjdev/nataddr-js.git"
   },
   "main": "dist/index.js",
+  "bin": "main.js",
   "scripts": {
     "build": "tsc",
     "test": "jest",
@@ -20,7 +21,8 @@
   "license": "ISC",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "main.js"
   ],
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
With this commit, `npx @cjdev/nataddr` will download the latest
version of this library and print out a tab-delimited list of
AddressType, IP pairs.  This makes this library useful for people who
don't have easy access to a npm project.