### PR TITLE
bug: fix npx script, add shell script to test it

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
-const nat = require("./dist/index");
+#!/usr/bin/env node
+const nat = require("./dist/index.js");
 
 console.log(
   nat

--- a/npx-test
+++ b/npx-test
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+if [[ -n "${DEBUG:-}" ]]; then
+  set -x
+fi
+
+cd "$(dirname "$(readlink "$0")")" 
+node_module="$(git rev-parse --show-toplevel)"
+tmpdir="$(mktemp -d)"
+
+cd "$tmpdir"
+function cleanup() {
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT TERM
+
+npm init -y &>/dev/null
+npm install "$node_module" &>/dev/null
+
+lines=$(npx -q @cjdev/nataddr | grep -c IP)
+
+echo "npx-test: ${lines##* } lines in output"
+(( lines > 0 ))


### PR DESCRIPTION
Still learning about how these scripts work :). They're shell scripts, so they need a shebang line at the top to work properly. I also added a script `./npx-test` that should print that some non-zero
number of lines was output by `npx @cjdev/nataddr` and exit with status 0